### PR TITLE
Avoid parsing index files more than once

### DIFF
--- a/repo.go
+++ b/repo.go
@@ -34,7 +34,7 @@ type idxFile struct {
 // commit, tree or blob, you do it from here.
 type Repository struct {
 	Path       string
-	indexfiles []*idxFile
+	indexfiles map[string]*idxFile
 
 	commitCache map[sha1]*Commit
 	tagCache    map[sha1]*Tag
@@ -60,13 +60,13 @@ func OpenRepository(path string) (*Repository, error) {
 	if err != nil {
 		return nil, err
 	}
-	repo.indexfiles = make([]*idxFile, len(indexfiles))
-	for i, indexfile := range indexfiles {
+	repo.indexfiles = make(map[string]*idxFile, len(indexfiles))
+	for _, indexfile := range indexfiles {
 		idx, err := readIdxFile(indexfile)
 		if err != nil {
 			return nil, err
 		}
-		repo.indexfiles[i] = idx
+		repo.indexfiles[indexfile] = idx
 	}
 
 	return repo, nil

--- a/repo_object.go
+++ b/repo_object.go
@@ -39,7 +39,7 @@ func (repo *Repository) getRawObject(id sha1, metaOnly bool) (ObjectType, int64,
 		// doesn't exist, let's look if we find the object somewhere else
 		for _, indexfile := range repo.indexfiles {
 			if offset := indexfile.offsetValues[id]; offset != 0 {
-				return readObjectBytes(indexfile.packpath, offset, metaOnly)
+				return readObjectBytes(indexfile.packpath, &repo.indexfiles, offset, metaOnly)
 			}
 		}
 		return 0, 0, nil, errors.New(fmt.Sprintf("Object not found %s", sha1))
@@ -67,7 +67,7 @@ func (repo *Repository) objectSize(id sha1) (int64, error) {
 		// doesn't exist, let's look if we find the object somewhere else
 		for _, indexfile := range repo.indexfiles {
 			if offset := indexfile.offsetValues[id]; offset != 0 {
-				_, length, _, err := readObjectBytes(indexfile.packpath, offset, true)
+				_, length, _, err := readObjectBytes(indexfile.packpath, &repo.indexfiles, offset, true)
 				return length, err
 			}
 		}

--- a/repo_utils.go
+++ b/repo_utils.go
@@ -113,7 +113,7 @@ func readLenInPackFile(buf []byte) (length int, advance int) {
 // non-delta object, the (inflated) bytes are just returned, if the object
 // is a deltafied-object, we have to apply the delta to base objects
 // before hand.
-func readObjectBytes(path string, offset uint64, sizeonly bool) (ot ObjectType, length int64, dataRc io.ReadCloser, err error) {
+func readObjectBytes(path string, indexfiles *map[string]*idxFile, offset uint64, sizeonly bool) (ot ObjectType, length int64, dataRc io.ReadCloser, err error) {
 	offsetInt := int64(offset)
 	file, err := os.Open(path)
 	if err != nil {
@@ -194,11 +194,7 @@ func readObjectBytes(path string, offset uint64, sizeonly bool) (ot ObjectType, 
 
 		pos = pos + 20
 
-		var f *idxFile
-		f, err = readIdxFile(path[0:len(path)-4] + "idx")
-		if err != nil {
-			return
-		}
+		f := (*indexfiles)[path[0:len(path)-4]+"idx"]
 		var ok bool
 		if baseObjectOffset, ok = f.offsetValues[id]; !ok {
 			log.Fatal("not implemented yet")
@@ -211,7 +207,7 @@ func readObjectBytes(path string, offset uint64, sizeonly bool) (ot ObjectType, 
 		base   []byte
 		baseRc io.ReadCloser
 	)
-	ot, _, baseRc, err = readObjectBytes(path, baseObjectOffset, false)
+	ot, _, baseRc, err = readObjectBytes(path, indexfiles, baseObjectOffset, false)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
In huge repositories, `readIdxFile()` can be quite slow. Since all index files are already read by `OpenRepository()`, it's useless to re-parse them when they are needed: we can just re-use what was read the first time.

I noticed this in a program I'm writing, that is essentially iterating over all the objects in the last commit of a specific branch. There are several thousands of objects in several hundreds of subtrees. On my underpowered ARM NAS, this was extremely slow: 2380 seconds on average. `go tool pprof` showed that about 90% of that time was spent in `readIdxFile()`. With this patch, the execution only takes 140 seconds on average.
