### PR TITLE
Parse packed-refs if heads file not found

### DIFF
--- a/repo_commit.go
+++ b/repo_commit.go
@@ -1,10 +1,12 @@
 package git
 
 import (
+	"bufio"
 	"container/list"
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -48,6 +50,9 @@ func (repo *Repository) getCommitIdOfRef(refpath string) (string, error) {
 start:
 	f, err := ioutil.ReadFile(filepath.Join(repo.Path, refpath))
 	if err != nil {
+		f, err = repo.getCommitIdOfPackedRef(refpath)
+	}
+	if err != nil {
 		return "", err
 	}
 
@@ -66,6 +71,28 @@ start:
 	// yes, it's "ref: something". Now let's lookup "something"
 	refpath = allMatches[0][1]
 	goto start
+}
+
+func (repo *Repository) getCommitIdOfPackedRef(refpath string) ([]byte, error) {
+	f, err := os.Open(filepath.Join(repo.Path, "packed-refs"))
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	scan := bufio.NewScanner(f)
+
+	for scan.Scan() {
+		if strings.Contains(scan.Text(), refpath) {
+			return scan.Bytes(), nil
+		}
+	}
+
+	if err := scan.Err(); err != nil {
+		return nil, err
+	}
+
+	return nil, errors.New("Ref not found in packed-refs")
 }
 
 // Find the commit object in the repository.

--- a/repo_commit.go
+++ b/repo_commit.go
@@ -54,6 +54,9 @@ start:
 	allMatches := refRexp.FindAllStringSubmatch(string(f), 1)
 	if allMatches == nil {
 		// let's assume this is a sha1
+		if len(f) < 40 {
+			return "", errors.New("sha1 hash too short")
+		}
 		sha1 := string(f[:40])
 		if !IsSha1(sha1) {
 			return "", fmt.Errorf("heads file wrong sha1 string %s", sha1)

--- a/tree.go
+++ b/tree.go
@@ -129,5 +129,5 @@ func (t *Tree) Scanner() (*TreeScanner, error) {
 	if err != nil {
 		return nil, err
 	}
-	return NewTreeScanner(t.Id, r), nil
+	return NewTreeScanner(t, r), nil
 }

--- a/tree_utils.go
+++ b/tree_utils.go
@@ -9,7 +9,7 @@ import (
 )
 
 type TreeScanner struct {
-	parent sha1
+	parent *Tree
 
 	*bufio.Scanner
 	closer io.Closer
@@ -18,7 +18,7 @@ type TreeScanner struct {
 	err       error
 }
 
-func NewTreeScanner(parent sha1, rc io.ReadCloser) *TreeScanner {
+func NewTreeScanner(parent *Tree, rc io.ReadCloser) *TreeScanner {
 	ts := &TreeScanner{
 		parent:  parent,
 		Scanner: bufio.NewScanner(rc),
@@ -52,10 +52,11 @@ func (t *TreeScanner) parse() error {
 	}
 
 	t.treeEntry = &TreeEntry{
-		name: name,
-		mode: entryMode,
-		Id:   id,
-		Type: objectType,
+		name:  name,
+		mode:  entryMode,
+		Id:    id,
+		Type:  objectType,
+		ptree: t.parent,
 	}
 
 	return nil


### PR DESCRIPTION
if git gc is run, it's possible heads are packed into .git/packed-refs and the files are deleted.