### PR TITLE
Fixed a weird invocation of crypto/sha1 which was causing a panic.

### DIFF
--- a/blob.go
+++ b/blob.go
@@ -3,7 +3,7 @@ package git
 import (
 	"bytes"
 	"compress/zlib"
-	"crypto"
+	libsha1 "crypto/sha1"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -74,7 +74,7 @@ func StoreObjectSHA(
 		return [20]byte{}, err
 	}
 
-	hash := crypto.SHA1.New()
+	hash := libsha1.New()
 	reader = io.TeeReader(reader, hash)
 
 	if w == ioutil.Discard {


### PR DESCRIPTION
When "StoreObjectSHA1" was called it was using a weird invocation
of crypto/sha1 by importing crypto and trying to use crypto.SHA1.New
instead of importing crypto/sha1 and using sha1.New. This was causing
a panic with the error "panic: crypto: requested hash function #3 is
unavailable"

This updates the call to use the crypto/sha1 package as documented in
the go docs.