### PR TITLE
fix packed files read for 1.7

### DIFF
--- a/repo_utils_reader.go
+++ b/repo_utils_reader.go
@@ -139,7 +139,7 @@ func readerApplyDelta(br io.ReaderAt, dr io.Reader, resultLen int64) (res []byte
 		n, err = r.Read(buf)
 		if err == io.EOF {
 			err = nil
-			return
+			return n == 1
 		}
 		if n == 0 || err != nil {
 			return
@@ -153,7 +153,7 @@ func readerApplyDelta(br io.ReaderAt, dr io.Reader, resultLen int64) (res []byte
 		n, err = r.ReadAt(buf, off)
 		if err == io.EOF {
 			err = nil
-			return
+			return n == 1
 		}
 		if n == 0 || err != nil {
 			return


### PR DESCRIPTION
this is just a quick fix to keep this in a running state. i'm more or less rewriting repo_utils.go and when testing on a git tree with packed files another early eof error occured. 
