### PR TITLE
Added comment to Repository.CommitsBefore() method.

### DIFF
--- a/repo_commit.go
+++ b/repo_commit.go
@@ -225,6 +225,10 @@ func (repo *Repository) CommitsBetween(last *Commit, before *Commit) (*list.List
 	return l, nil
 }
 
+// CommitsBefore returns a list of all commits before commitId and *also*
+// includes the *Commit representing commitId in the list.
+//
+// The (list.Element).Value of the list returned if of type *Commit.
 func (repo *Repository) CommitsBefore(commitId string) (*list.List, error) {
 	id, err := NewIdFromString(commitId)
 	if err != nil {


### PR DESCRIPTION
It took me a couple minutes to figure out how to use CommitsBefore(), so I wrote a func comment based on how it appears to be working.

(It's also not really clear to me why it uses a list.List that requires reflection and the knowledge it's a *Commit and not a Commit to get the value out instead of just returning a []*Commit slice, but that's a larger refactor that I'm not really comfortable making..)